### PR TITLE
Makes images in the roadmap show up correctly.

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -99,19 +99,19 @@ ol.milestones li ul {
         content: " ";
     }
     li.status-done:before {
-        background-image: url(/images/icons/done-21.png);
+        content: url(/images/icons/done-21.png);
     }
     li.status-todo:before {
-        background-image: url(/images/icons/todo-21.png);
+        content: url(/images/icons/todo-21.png);
     }
     li.status-wip:before {
-        background-image: url(/images/icons/wip-21.png);
+        content: url(/images/icons/wip-21.png);
     }
     li.status-blocked:before {
-        background-image: url(/images/icons/blocked-21.png);
+        content: url(/images/icons/blocked-21.png);
     }
     li.status-maybe:before {
-        background-image: url(/images/icons/maybe-21.png);
+        content: url(/images/icons/maybe-21.png);
     }
 }
 


### PR DESCRIPTION
Firefox's high-contrast accessibility settings remove `background-image`
elements, but `::before` can display images just fine using `content`;
this should work for you with no problems.

~~Please accept this as an apology for me forgetting about the issue on Twitter~~ :smile: 