### PR TITLE
Pull out roadmap into a function; add alttext to status

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,9 @@ asciidoctor:
 plugins:
     - jekyll-asciidoc
 
+roadmap_images:
+  done: /images/icons/done-21.png
+  todo: /images/icons/todo-21.png
+  wip: /images/icons/wip-21.png
+  blocked: /images/icons/blocked-21.png
+  maybe: /images/icons/maybe-21.png

--- a/_data/roadmap1.yml
+++ b/_data/roadmap1.yml
@@ -1,0 +1,22 @@
+- name: Hello World
+  toplevel: true
+  subitems:
+    - name: Bytecode assembly tool
+      status: done
+    - name: Basic bytecode interpreter
+      status: done
+      subitems:
+        - name: Bytecode loading
+          status: done
+        - name: Token threaded bytecode execution
+          status: done
+        - name: Bytecode hello world
+          status: done
+        - name: Basic suite of instructions
+          status: done
+        - name: Blocks and control flow
+          status: done
+        - name: Bytecode fibs
+          status: done
+    - name: Basic compiler that can handle "Hello, World!"
+      status: done

--- a/_data/roadmap2.yml
+++ b/_data/roadmap2.yml
@@ -1,0 +1,88 @@
+- name: Language Groundwork
+  toplevel: true
+  subitems:
+    - name: Language syntax
+      status: done
+      subitems:
+        - name: Basic statements and expressions
+          status: done
+        - name: Case statments
+          status: done
+        - name: 'If-then-else'
+          status: done
+        - name: Basic pattern matching
+          status: done
+    - name: Type system
+      status: wip
+      subitems:
+        - name: Basic builtin types
+          status: done
+        - name: Sum types
+          status: done
+        - name: Product types
+          status: done
+        - name: Generics
+          status: done
+        - name: Higher order values
+          status: done
+        - name: Interfaces
+          status: todo
+    - name: Basic resource system
+      status: done
+    - name: Basic module system
+      status: todo
+    - name: Basic functional features
+      status: wip
+      subitems:
+        - name: Higher order calls
+          status: done
+        - name: 'Lambda expressions &amp; closures'
+          status: todo
+        - name: Partial application
+          status: todo
+    - name: Prelude or basic libraries
+      status: blocked
+    - name: More examples
+      status: todo
+    - name: Runtime system
+      status: todo
+      subitems:
+        - name: 'Multi-module bytecode loading'
+          status: todo
+        - name: Basic Garbage Collection
+          status: todo
+- name: 'Concurrency and Parallelism (<span class="codename">Nebula</span>)'
+  subitems:
+    - name: Concurrency and Parallelism
+      status: todo
+      subitems:
+        - name: Lightweight threads
+          status: todo
+        - name: 'Basic concurrent communications (channels, mvars etc)'
+          status: todo
+    - name: Language syntax
+      status: todo
+      subitems:
+        - name: 'Syntax for lists, dicts etc'
+          status: wip
+        - name: Loops
+          status: todo
+        - name: Scopes
+          status: todo
+        - name: State variable notation
+          status: todo
+        - name: Multi-valued expressions
+          status: done
+        - name: 'Expression versions of if-then-else and match (w/ multi-values)'
+          status: todo
+        - name: 'Module expressions &amp; module import within code'
+          status: todo
+    - name: Runtime system improvements
+      status: todo
+      subitems:
+        - name: 'Operations for different data-widths'
+          status: done
+        - name: 'Subroutine threaded bytecode execution (amd64)'
+          status: todo
+        - name: 'N:M multi-threading'
+          status: todo

--- a/_data/roadmap3.yml
+++ b/_data/roadmap3.yml
@@ -1,0 +1,79 @@
+- name: 'Self hosting ready (<span class="codename">Stella nursery</span>)'
+  toplevel: true
+  subitems:
+  - name: 'String builtin type'
+    status: todo
+  - name: 'Exceptions'
+    status: todo
+  - name: 'Basic IO Library'
+    status: blocked
+  - name: 'Basic Datastructures Library'
+    status: blocked
+  - name: '...'
+    status: todo
+- name: 'Bootstraps ("Protostar")'
+- name: 'Features and Optimisations ("T-Tauri")'
+  subitems:
+  - name: 'Type system improvments'
+    status: todo
+    subitems:
+    - name: 'Integers of different widths'
+      status: todo
+    - name: 'Arrays'
+      status: todo
+    - name: 'HKTs'
+      status: maybe
+    - name: 'Uniqueness (for resources)'
+      status: todo
+  - name: 'More expressativity'
+    status: todo
+    subitems:
+    - name: 'Better pattern matching (multiple matches, guards, nesting etc)'
+      status: todo
+    - name: 'Deconstruction without match'
+      status: todo
+    - name: 'Field access, update and conditional update'
+      status: todo
+    - name: 'Early return'
+      status: todo
+    - name: '...'
+      status: todo
+  - name: 'More complete resource system'
+    status: todo
+  - name: 'Runtime system improvements'
+    status: blocked
+  - name: 'Basic Optimisations'
+    status: blocked
+  - name: 'More Parallelism and Concurrency'
+    status: blocked
+    subitems:
+    - name: 'Parallel loops'
+      status: blocked
+    - name: 'STM and other concurrency primatives'
+      status: blocked
+  - name: 'Better libraries'
+    status: blocked
+  - name: '...'
+    status: todo
+- name: '1.0 (<span class="codename">Star</span>)'
+  subitems:
+  - name: 'Bug fixing'
+    status: blocked
+  - name: 'Documentation'
+    status: blocked
+  - name: 'Polishing off rough edges (TBA)'
+    status: blocked
+  - name: '...'
+    status: todo
+- name: 'Future'
+  subitems:
+  - name: 'Optimisations'
+    status: blocked
+  - name: 'Improved code generation'
+    status: blocked
+  - name: 'Native code / LLVM (maybe)'
+    status: blocked
+  - name: 'Improved Garbage Collection'
+    status: blocked
+  - name: 'Plenty of other ideas'
+    status: blocked

--- a/_includes/functions/show_roadmap.html
+++ b/_includes/functions/show_roadmap.html
@@ -1,0 +1,22 @@
+{% if include.roadmap[0].toplevel == true %}
+<ol class="milestones" start="{{include.start | default: 1}}">
+{% else %}
+<ul>
+{% endif %}
+  {% for navitem in include.roadmap %}
+    <li class="status-{{navitem.status | default: todo}}">
+      {% if navitem.status %}
+      <img src="{{site.roadmap_images[navitem.status]}}" alt="Status: {{navitem.status}}"/>
+      {% endif %}
+      {{navitem.name}}
+    {% if navitem.subitems %}
+      {% include /functions/show_roadmap.html roadmap=navitem.subitems %}
+    {% endif %}
+    {{list_type}}
+    </li>
+  {% endfor %}
+{% if include.roadmap[0].toplevel == true %}
+</ol>
+{% else %}
+</ul>
+{% endif %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -98,21 +98,6 @@ ol.milestones li ul {
         height: 21px;
         content: " ";
     }
-    li.status-done:before {
-        content: url(/images/icons/done-21.png);
-    }
-    li.status-todo:before {
-        content: url(/images/icons/todo-21.png);
-    }
-    li.status-wip:before {
-        content: url(/images/icons/wip-21.png);
-    }
-    li.status-blocked:before {
-        content: url(/images/icons/blocked-21.png);
-    }
-    li.status-maybe:before {
-        content: url(/images/icons/maybe-21.png);
-    }
 }
 
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -36,22 +36,7 @@ Although there are many rough edges, this milestone is now complete, and the
 rough edges have been moved to our <a href="docs/todo.html">TODO list</a>.
 </p>
 
-<ol class="milestones">
-  <li class="status-done">Hello World
-  <ul>
-    <li class="status-done">Bytecode assembly tool</li>
-    <li class="status-done">Basic bytecode interpreter
-    <ul>
-      <li class="status-done">Bytecode loading</li>
-      <li class="status-done">Token threaded bytecode execution</li>
-      <li class="status-done">Bytecode hello world</li>
-      <li class="status-done">Basic suite of instructions</li>
-      <li class="status-done">Blocks and control flow</li>
-      <li class="status-done">Bytecode fibs</li>
-    </ul></li>
-    <li class="status-done">Basic compiler that can handle "Hello world!"</li>
-  </ul></li>
-</ol>
+{% include functions/show_roadmap.html roadmap=site.data.roadmap1 %}
 
 <p>
 The goal of the second and third milestones, are to be able to
@@ -65,75 +50,7 @@ it will introduce parallelism and concurrency and features that are unique
 to Plasma.
 </p>
 
-<ol class="milestones" start="2">
-  <li>Language Groundwork
-  <ul>
-    <li class="status-done">Language syntax
-    <ul>
-      <li class="status-done">Basic statements and expressions</li>
-      <li class="status-done">Case statments</li>
-      <li class="status-done">If-then-else</li>
-      <li class="status-done">Basic pattern matching</li>
-    </ul></li>
-    <li class="status-wip">Type system
-    <ul>
-      <li class="status-done">Basic builtin types</li>
-      <li class="status-done">Sum types</li>
-      <li class="status-done">Product types</li>
-      <li class="status-done">Generics</li>
-      <li class="status-done">Higher order values</li>
-      <li class="status-todo">Interfaces</li>
-    </ul></li>
-    <li class="status-done">Basic resource system</li>
-    <li class="status-todo">Basic module system
-    <li class="status-wip">Basic functional features
-    <ul>
-      <li class="status-done">Higher order calls</li>
-      <li class="status-todo">Lambda expressions &amp; closures</li>
-      <!-- don't forget to enabling partial application (and generally
-        functional useage) of cunstructors -->
-      <li class="status-todo">Partial application</li>
-    </ul></li>
-    <li class="status-blocked">Prelude or basic libraries</li>
-    <li class="status-todo">More examples</li>
-    <li class="status-todo">Runtime system
-    <ul>
-      <li class="status-todo">Multi-module bytecode loading</li>
-      <li class="status-todo">Basic Garbage Collection</li>
-    </ul></li>
-  </ul></li>
-  <li>Concurrency and Parallelism (<span class="codename">Nebula</span>)
-  <ul>
-    <li class="status-todo">Concurrency and Parallelism
-    <ul>
-      <li class="status-todo">Lightweight threads</li>
-      <li class="status-todo">Basic concurrent communications
-        (channels, mvars etc)</li>
-    </ul></li>
-    <li class="status-todo">Language syntax
-    <ul>
-      <li class="status-wip">Syntax for lists, dicts etc</li>
-      <li class="status-todo">Loops</li>
-      <li class="status-todo">Scopes</li>
-      <li class="status-todo">State variable notation</li>
-      <li class="status-done">Multi-valued expressions</li>
-      <li class="status-todo">Expression versions of if-then-else and
-        match (w/ multi-values)</li>
-      <li class="status-todo">Module expressions &amp; module import within
-        code</li>
-    </ul></li>
-    <li class="status-todo">Runtime system improvements
-    <ul>
-      <li class="status-done">Operations for different data-widths</li>
-      <li class="status-todo">Subroutine threaded bytecode execution
-        (amd64)</li>
-      <li class="status-todo">N:M multi-threading</li>
-      <!--
-      <li class="status-todo">Support labels in data (for computed gotos)</li>
-      -->
-    </ul></li>
-  </ul></li>
-</ol>
+{% include functions/show_roadmap.html start=2 roadmap=site.data.roadmap2 %}
 
 <p>
 The remaining milestones represent steps towards a stable release.
@@ -141,63 +58,7 @@ While we're revising all the milestones as we go, milestones 4 and onwards
 are the most-likely milestones to change.
 </p>
 
-<ol class="milestones" start="4">
-  <li class="status-todo">Self hosting ready
-      (<span class="codename">Stella nursery</span>)
-  <ul>
-    <li class="status-todo">String builtin type</li>
-    <li class="status-todo">Exceptions</li>
-    <li class="status-blocked">Basic IO Library</li>
-    <li class="status-blocked">Basic Datastructures Library</li>
-    <li class="status-todo">...</li>
-  </ul></li>
-  <li class="status-todo">Bootstraps ("Protostar")</li>
-  <li class="status-todo">Features and Optimisations ("T-Tauri")
-  <ul>
-    <li class="status-todo">Type system improvments
-    <ul>
-      <li class="status-todo">Integers of different widths</li>
-      <li class="status-todo">Arrays</li>
-      <li class="status-maybe">HKTs</li>
-      <li class="status-todo">Uniqueness (for resources)</li>
-    </ul></li>
-    <li class="status-todo">More expressativity
-    <ul>
-      <li class="status-todo">Better pattern matching (multiple matches,
-        guards, nesting etc)</li>
-      <li class="status-todo">Deconstruction without match</li>
-      <li class="status-todo">Field access, update and conditional
-        update</li>
-      <li class="status-todo">Early return</li>
-      <li class="status-todo">...</li>
-    </ul></li>
-    <li class="status-todo">More complete resource system</li>
-    <li class="status-blocked">Runtime system improvements</li>
-    <li class="status-blocked">Basic Optimisations</li>
-    <li class="status-blocked">More Parallelism and Concurrency
-    <ul>
-      <li class="status-blocked">Parallel loops</li>
-      <li class="status-blocked">STM and other concurrency primatives</li>
-    </ul></li>
-    <li class="status-blocked">Better libraries</li>
-    <li class="status-todo">...</li>
-  </ul></li>
-  <li class="status-todo">1.0 (<span class="codename">Star</span>)
-  <ul>
-    <li class="status-blocked">Bug fixing</li>
-    <li class="status-blocked">Documentation</li>
-    <li class="status-blocked">Polishing off rough edges (TBA)</li>
-    <li class="status-todo">...</li>
-  </ul></li>
-  <li class="status-todo">Future
-  <ul>
-    <li class="status-blocked">Optimisations</li>
-    <li class="status-blocked">Improved code generation</li>
-    <li class="status-blocked">Native code / LLVM (maybe)</li>
-    <li class="status-blocked">Improved Garbage Collection</li>
-    <li class="status-blocked">Plenty of other ideas</li>
-  </ul></li>
-</ol>
+{% include functions/show_roadmap.html start=4 roadmap=site.data.roadmap3 %}
 
 <h2>Staying informed</h2>
 


### PR DESCRIPTION
TL;DR - **Even more accessibility improvements.**

The last PR got me thinking - there are people using screenreaders or
non-graphical browsers, and with the current approach, they wouldn't be
able to know the status of roadmap elements. This commit does two
things:

* First, it pulls out the roadmap data into YAML files, so that editing
  it is at least as easy, and at most even easier, than editing the raw
  HTML and using CSS class for status - and adds a recursive function
  that handles the logic for displaying the roadmap (a neat Jekyll trick
  I learned while writing Github Pages docs for Foxlang). That way, we
  can easily show the roadmap elsewhere or add a new roadmap with
  minimal effort, and roadmap.html is a bit easier to read in an editor.

* Second, it removes the `::before` attribute from the list elements,
  and instead uses an actual `<img>` tag to display the status icons -
  and assigns `alt` attributes. This way, if someone's using a
  non-graphical browser or a screen reader, they will still see a
  "Status: todo" etc. text, while users with full image support will see
  no change from the current state.