### PR TITLE
Fix legend icon sizing

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -84,7 +84,7 @@ dd {
     margin-bottom: 1em;
 }
 
-ol.milestones li ul {
+ol.milestones li ul, .roadmap-legend li {
     list-style-type: none;
 }
 ol.milestones > li > ul {

--- a/roadmap.html
+++ b/roadmap.html
@@ -16,32 +16,28 @@ each of which is broken into a number of tasks.
 </p>
 
 <h2>Legend</h2>
-<table>
-<tbody>
-<tr>
-  <td><img alt="stylised red X" src="images/icons/todo-21.png"></td>
-  <td>TODO, Not started</td>
-</tr>
-<tr>
-  <td><img alt="Roadwork sign" src="images/icons/wip-21.png"></td>
-  <td>Work in progress</td>
-</tr>
-<tr>
-  <td><img alt="Green check mark" src="images/icons/done-21.png"></td>
-  <td>Done</td>
-</tr>
-<tr>
-  <td><img alt="Common road stop sign" src="images/icons/blocked-21.png"></td>
-  <td>Blocked</td>
-</tr>
-<tr>
-  <td>
-    <img alt="Questionmark in blue circle" src="images/icons/maybe-21.png">
-  </td>
-  <td>Might happen (sometime/never or now/later).</td>
-</tr>
-</tbody>
-</table>
+<ul class="roadmap-legend">
+<li>
+  <img alt="stylised red X" src="images/icons/todo-21.png">
+  TODO, Not started
+</li>
+<li>
+  <img alt="Roadwork sign" src="images/icons/wip-21.png">
+  Work in progress
+</li>
+<li>
+  <img alt="Green check mark" src="images/icons/done-21.png">
+  Done
+</li>
+<li>
+  <img alt="Common road stop sign" src="images/icons/blocked-21.png">
+  Blocked
+</li>
+<li>
+  <img alt="Questionmark in blue circle" src="images/icons/maybe-21.png">
+  Might happen (sometime/never or now/later).
+</li>
+</ul>
 
 <h2>Milestones</h2>
 


### PR DESCRIPTION
Fixes #17.

The legend was previously a `table`, so the icons were constrained to the table cells + any margins and padding those might have. By making the legend a list, like the roadmap itself is, we get uniform styling between the legend and roadmap.

Before -> After
![image](https://user-images.githubusercontent.com/35173529/123635545-1355b500-d81c-11eb-9d6e-e95847f01373.png)
